### PR TITLE
Adding to environment-cpu/gpu

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -2,6 +2,8 @@ name: condaenv
 channels:
   - conda-forge
 dependencies:
+  - graph-tool=2.45
+  - jax=0.3.20
   - keras=2.10.0
   - loguru=0.6.0
   - mkl=2022.1.0
@@ -18,4 +20,9 @@ dependencies:
   - tensorflow-cpu=2.10.0
   - tqdm=4.64.1
   - pip:
-      - flwr[simulation]==1.1.0
+    - dm-haiku==0.0.8
+    - flwr[simulation]==1.1.0
+    - opacus==1.3.0
+    - optax==0.1.3
+    - tensorflow_privacy==0.7.3
+    - tensorflow-probability==0.15.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -1,7 +1,11 @@
 name: condaenv
 channels:
   - conda-forge
+  - nvidia
 dependencies:
+  - cuda-nvcc=12.0.76
+  - graph-tool=2.45
+  - jax=0.3.20
   - keras=2.10.0
   - loguru=0.6.0
   - mkl=2022.1.0
@@ -18,4 +22,9 @@ dependencies:
   - tensorflow-gpu=2.10.0
   - tqdm=4.64.1
   - pip:
-      - flwr[simulation]==1.1.0
+    - dm-haiku==0.0.8
+    - flwr[simulation]==1.1.0
+    - opacus==1.3.0
+    - optax==0.1.3
+    - tensorflow_privacy==0.7.3
+    - tensorflow-probability==0.15.0


### PR DESCRIPTION
This PR adds
- `jax`/`haiku`/`optax` for NN training in JAX
  - the GPU version needs the `nvidia` channel to install corresponding cuda compiler
- DP related packages
  - `tf_privacy`/`tf_probability`
  - `opacus` for PyTorch private training
- A graph analysis package (`graph-tool`)