### PR TITLE
Added 5 and changed version for 1

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -56,7 +56,3 @@ dependencies:
       - tensorflow_privacy==0.7.3
       - tensorflow-probability==0.15.0
       - deepwalk==1.0.3
-      - imblearn==0.0
-      - gensim==3.8.3
-      - tensorboard-logger==0.1.0
-      - futures==2.1.6

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -55,3 +55,7 @@ dependencies:
       - python-dp==1.1.1
       - tensorflow_privacy==0.7.3
       - tensorflow-probability==0.15.0
+      - deepwalk==1.0.3
+      - imblearn==0.0
+      - gensim==3.8.3
+      - tensorboard-logger==0.1.0

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -59,3 +59,4 @@ dependencies:
       - imblearn==0.0
       - gensim==3.8.3
       - tensorboard-logger==0.1.0
+      - futures==2.1.6

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -57,7 +57,3 @@ dependencies:
       - tensorflow_privacy==0.7.3
       - tensorflow-probability==0.15.0
       - deepwalk==1.0.3
-      - imblearn==0.0
-      - gensim==3.8.3
-      - tensorboard-logger==0.1.0
-      - futures==2.1.6

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -60,3 +60,4 @@ dependencies:
       - imblearn==0.0
       - gensim==3.8.3
       - tensorboard-logger==0.1.0
+      - futures==2.1.6

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -56,3 +56,7 @@ dependencies:
       - python-dp==1.1.1
       - tensorflow_privacy==0.7.3
       - tensorflow-probability==0.15.0
+      - deepwalk==1.0.3
+      - imblearn==0.0
+      - gensim==3.8.3
+      - tensorboard-logger==0.1.0


### PR DESCRIPTION
Added the following 5
- deepwalk==1.0.3
- imblearn==0.0
- gensim==3.8.3
- tensorboard-logger==0.1.0
- futures==2.1.6

Our code isn't working with igraph 0.10.2, but works with 0.9.11. 
@jayqi : I believe this was added my another team so am not sure if the version change breaks stuff for them. Please suggest what would be the best way forward