### PR TITLE
Pin cudatoolkit and build strings to CUDA 11.2

### DIFF
--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,6 +1,6 @@
 FROM nvidia/cuda:11.0.3-base-ubuntu20.04
-# adapated from build file for pangeo images
-# https://github.com/pangeo-data/pangeo-docker-images
+# This CUDA version does not matter
+# We will separately install the CUDA runtime via cudatoolkit using conda
 
 ARG CPU_OR_GPU=gpu
 

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -5,8 +5,8 @@ dependencies:
   - cachetools=5.2.1
   - cloudpickle=2.1.0
   - cryptography=38.0.4
-  - nvidia::cuda-nvcc=12.0.76
   - cudatoolkit=11.2
+  - cudatoolkit-dev=11.2
   - datasets=1.18.3
   - dm-haiku=0.0.8
   - filelock=3.3.1

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -6,6 +6,7 @@ dependencies:
   - cloudpickle=2.1.0
   - cryptography=38.0.4
   - nvidia::cuda-nvcc=12.0.76
+  - cudatoolkit=11.2
   - datasets=1.18.3
   - dm-haiku=0.0.8
   - filelock=3.3.1
@@ -18,6 +19,7 @@ dependencies:
   - hyperopt=0.2.7
   - imbalanced-learn=0.10.0
   - jax=0.3.20
+  - jaxlib=0.3.20=cuda112py39*
   - keras=2.10.0
   - lightgbm=3.1.1
   - loguru=0.6.0
@@ -41,19 +43,19 @@ dependencies:
   - python-igraph=0.10.2
   - python-lmdb=1.3.0
   - python-xxhash=2.0.2
-  - pytorch-gpu=1.12.1
+  - pytorch-gpu=1.12.1=cuda112py39*
   - pytorch-lightning=1.7.6
   - ray-tune=1.6.0
   - rsa=4.7.2
   - ruamel.yaml=0.17.21
   - scikit-learn=1.1.2
   - scipy=1.9.1
-  - tensorflow-gpu=2.10.0
+  - tensorflow-gpu=2.10.0=cuda112py39*
   - tokenizers=0.10.3
   - torchmetrics=0.11.0
   - tqdm=4.64.1
   - transformers=4.8.2
-  - xgboost=1.7.1
+  - xgboost=1.7.1=cuda112py39*
   - pip:
       - apsw==3.9.2-r1
       - flwr[simulation]==1.1.0


### PR DESCRIPTION
This PR replaces `nvidia::cuda-nvcc` with `cudatoolkit-dev` and explicitly pins `cudatoolkit` and other CUDA-dependent packages to CUDA 11.2 for consistency. 

Previously, this was happening implicitly. All CUDA-dependent packages were built for 11.2, while cudatoolkit 11.8 was being installed, and `nvidia::cuda-nvcc` was the newest version 12.0.76. 

See discussion in [this forum post](https://community.drivendata.org/t/version-consistency-between-cuda-pytorch-and-other-related-modules/8462).