### PR TITLE
adding dependency: pytorch-geometric=2.2.0

### DIFF
--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -37,6 +37,7 @@ dependencies:
   - pycryptodome=3.16.0
   - pycryptodomex=3.16.0
   - pynacl=1.5.0
+  - pytorch_geometric=2.2.0
   - pytest=7.1.3
   - python=3.9.13
   - python-duckdb=0.6.1


### PR DESCRIPTION
This is related to discussion:
:: Version consistency between CUDA, PyTorch and other related modules - PETs Prize Challenge - DrivenData Community https://community.drivendata.org/t/version-consistency-between-cuda-pytorch-and-other-related-modules/8462/3