### PR TITLE
Set num_cpus client request to half+1

### DIFF
--- a/runtime/main_federated_test.py
+++ b/runtime/main_federated_test.py
@@ -58,12 +58,15 @@ if __name__ == "__main__":
     )
     server_config = fl.server.ServerConfig(num_rounds=num_rounds)
 
-    # start simulation
+    # Set CPUs more than half of available to prevent multiple clients from running
+    # concurrently. Only used for scheduling—will not limit actual CPU usage.
     client_resources = {
-        "num_cpus": os.cpu_count() - 1,
+        "num_cpus": int(os.cpu_count() / 2) + 1,
     }
     if os.getenv("CPU_OR_GPU", "") == "gpu":
         client_resources["num_gpus"] = 1
+
+    # start simulation
     fl.simulation.start_simulation(
         client_fn=wrapped_client_factory,
         clients_ids=supervisor.get_client_ids(),

--- a/runtime/main_federated_train.py
+++ b/runtime/main_federated_train.py
@@ -73,12 +73,15 @@ if __name__ == "__main__":
     )
     server_config = fl.server.ServerConfig(num_rounds=num_rounds)
 
-    # start simulation
+    # Set CPUs more than half of available to prevent multiple clients from running
+    # concurrently. Only used for scheduling—will not limit actual CPU usage.
     client_resources = {
-        "num_cpus": os.cpu_count() - 1,
+        "num_cpus": int(os.cpu_count() / 2) + 1,
     }
     if os.getenv("CPU_OR_GPU", "") == "gpu":
         client_resources["num_gpus"] = 1
+
+    # start simulation
     fl.simulation.start_simulation(
         client_fn=wrapped_client_factory,
         clients_ids=supervisor.get_client_ids(),


### PR DESCRIPTION
Sets the client num_cpus request to (half+1), rather than (all-1). This setting is used for scheduling, and it just needs to be more than half to prevent clients running concurrently. It does not limit any actual usage ([reference](https://discuss.ray.io/t/specify-the-number-of-worker-processes/2118/6)). We have seen some submissions occasionally get stalled because Ray is not finding (all-1) CPUs available for some reason. 